### PR TITLE
Prevent multiple upload prompt from closing when background clicked

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -36,7 +36,7 @@ dependencies {
 
 sourceCompatibility = '1.7'
 group = 'org.opencadc'
-version = '1.1.29'
+version = '1.1.30'
 mainClassName = "ca.nrc.cadc.beacon.web.restlet.VOSpaceApplication"
 
 run {

--- a/src/main/resources/META-INF/resources/js/filemanager.js
+++ b/src/main/resources/META-INF/resources/js/filemanager.js
@@ -3173,10 +3173,16 @@ function fileManager(_initialData, _$beaconTable, _startURI, _folderPath,
                                    var btns = {};
                                    btns[lg.close] = false;
                                    $.prompt(msg, {
-                                     buttons: btns
+                                     buttons: btns,
+                                       persisent: true,
+                                       loaded: function () {
+                                           // rt 74147: block closing multiple upload popup
+                                           // through clicking on background.
+                                           $(".jqifade").off().click( function(event) {
+                                               event.preventDefault();
+                                           });
+                                       }
                                    });
-
-
 
                                    var $progressBar = $("#total-progress").find(".progress-bar");
 

--- a/src/main/resources/META-INF/resources/js/filemanager.js
+++ b/src/main/resources/META-INF/resources/js/filemanager.js
@@ -3174,14 +3174,13 @@ function fileManager(_initialData, _$beaconTable, _startURI, _folderPath,
                                    btns[lg.close] = false;
                                    $.prompt(msg, {
                                      buttons: btns,
-                                       persisent: true,
-                                       loaded: function () {
-                                           // rt 74147: block closing multiple upload popup
-                                           // through clicking on background.
-                                           $(".jqifade").off().click( function(event) {
-                                               event.preventDefault();
-                                           });
-                                       }
+                                     loaded: function () {
+                                         // rt 74147: block closing multiple upload popup
+                                         // through clicking on background.
+                                         $(".jqifade").off().click( function(event) {
+                                             event.preventDefault();
+                                         });
+                                     }
                                    });
 
                                    var $progressBar = $("#total-progress").find(".progress-bar");


### PR DESCRIPTION
Only controls multiple upload prompt. Must now be explicitly closed using 'x' or Close button.