### PR TITLE
s2346, ta 10892: change URI to GroupURI for read and write groups so …

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -36,7 +36,7 @@ dependencies {
 
 sourceCompatibility = '1.7'
 group = 'org.opencadc'
-version = '1.1.32'
+version = '1.1.33'
 mainClassName = "ca.nrc.cadc.beacon.web.restlet.VOSpaceApplication"
 
 run {

--- a/src/main/java/ca/nrc/cadc/beacon/web/StorageItemFactory.java
+++ b/src/main/java/ca/nrc/cadc/beacon/web/StorageItemFactory.java
@@ -68,6 +68,7 @@
 
 package ca.nrc.cadc.beacon.web;
 
+import ca.nrc.cadc.ac.GroupURI;
 import ca.nrc.cadc.auth.AuthMethod;
 import ca.nrc.cadc.auth.AuthenticationUtil;
 import ca.nrc.cadc.beacon.web.view.*;
@@ -173,9 +174,9 @@ public class StorageItemFactory
         final String lockedFlagValue = node.getPropertyValue(VOS.PROPERTY_URI_ISLOCKED);
         final boolean lockedFlag = StringUtil.hasText(lockedFlagValue) && Boolean.parseBoolean(lockedFlagValue);
         final String writeGroupValues = node.getPropertyValue(VOS.PROPERTY_URI_GROUPWRITE);
-        final URI[] writeGroupURIs = uriExtractor.extract(writeGroupValues);
+        final GroupURI[] writeGroupURIs = uriExtractor.extract(writeGroupValues);
         final String readGroupValues = node.getPropertyValue(VOS.PROPERTY_URI_GROUPREAD);
-        final URI[] readGroupURIs = uriExtractor.extract(readGroupValues);
+        final GroupURI[] readGroupURIs = uriExtractor.extract(readGroupValues);
 
         final String readableFlagValue = node.getPropertyValue(VOS.PROPERTY_URI_READABLE);
         final boolean readableFlag = StringUtil.hasLength(readableFlagValue) && Boolean.parseBoolean(readableFlagValue);

--- a/src/main/java/ca/nrc/cadc/beacon/web/URIExtractor.java
+++ b/src/main/java/ca/nrc/cadc/beacon/web/URIExtractor.java
@@ -68,30 +68,31 @@
 
 package ca.nrc.cadc.beacon.web;
 
+import ca.nrc.cadc.ac.GroupURI;
 import ca.nrc.cadc.util.StringUtil;
 
 import java.net.URI;
 
 public class URIExtractor
 {
-    public URI[] extract(final String groupPropertyValue)
+    public GroupURI[] extract(final String groupPropertyValue)
     {
-        final URI[] uris;
+        final GroupURI[] uris;
 
         if (StringUtil.hasText(groupPropertyValue))
         {
             final String[] uriValues = extractAsStrings(groupPropertyValue);
             final int len = uriValues.length;
-            uris = new URI[len];
+            uris = new GroupURI[len];
 
             for (int i = 0; i < len; i++)
             {
-                uris[i] = URI.create(uriValues[i]);
+                uris[i] = new GroupURI(uriValues[i]);
             }
         }
         else
         {
-            uris = new URI[0];
+            uris = new GroupURI[0];
         }
 
         return uris;

--- a/src/main/java/ca/nrc/cadc/beacon/web/view/FileItem.java
+++ b/src/main/java/ca/nrc/cadc/beacon/web/view/FileItem.java
@@ -68,6 +68,7 @@
 
 package ca.nrc.cadc.beacon.web.view;
 
+import ca.nrc.cadc.ac.GroupURI;
 import ca.nrc.cadc.vos.VOSURI;
 
 import java.net.URI;
@@ -78,7 +79,7 @@ public class FileItem extends StorageItem
 {
     public FileItem(VOSURI uri, long sizeInBytes, Date lastModified,
                     boolean publicFlag, boolean lockedFlag,
-                    URI[] writeGroupURIs, URI[] readGroupURIs, String owner,
+                    GroupURI[] writeGroupURIs, GroupURI[] readGroupURIs, String owner,
                     boolean readableFlag, boolean writableFlag, final String targetURL)
     {
         super(uri, sizeInBytes, lastModified, publicFlag, lockedFlag,

--- a/src/main/java/ca/nrc/cadc/beacon/web/view/FolderItem.java
+++ b/src/main/java/ca/nrc/cadc/beacon/web/view/FolderItem.java
@@ -68,6 +68,7 @@
 
 package ca.nrc.cadc.beacon.web.view;
 
+import ca.nrc.cadc.ac.GroupURI;
 import ca.nrc.cadc.vos.VOSURI;
 
 import java.net.URI;
@@ -81,7 +82,7 @@ public class FolderItem extends StorageItem
 
     public FolderItem(VOSURI uri, long sizeInBytes, Date lastModified,
                       boolean publicFlag, boolean lockedFlag,
-                      URI[] writeGroupURIs, URI[] readGroupURIs, String owner,
+                      GroupURI[] writeGroupURIs, GroupURI[] readGroupURIs, String owner,
                       boolean readableFlag, final boolean writableFlag,
                       final int childCount, String targetURL)
     {

--- a/src/main/java/ca/nrc/cadc/beacon/web/view/LinkItem.java
+++ b/src/main/java/ca/nrc/cadc/beacon/web/view/LinkItem.java
@@ -1,5 +1,6 @@
 package ca.nrc.cadc.beacon.web.view;
 
+import ca.nrc.cadc.ac.GroupURI;
 import ca.nrc.cadc.vos.VOSURI;
 
 import java.net.URI;
@@ -13,7 +14,7 @@ public class LinkItem extends StorageItem
 {
     public LinkItem(VOSURI uri, long sizeInBytes, Date lastModified,
                     boolean publicFlag, boolean lockedFlag,
-                    URI[] writeGroupURIs, URI[] readGroupURIs,
+                    GroupURI[] writeGroupURIs, GroupURI[] readGroupURIs,
                     String owner, boolean readableFlag, boolean writableFlag, String targetURL)
     {
         super(uri, sizeInBytes, lastModified, publicFlag, lockedFlag,

--- a/src/main/java/ca/nrc/cadc/beacon/web/view/StorageItem.java
+++ b/src/main/java/ca/nrc/cadc/beacon/web/view/StorageItem.java
@@ -68,6 +68,7 @@
 
 package ca.nrc.cadc.beacon.web.view;
 
+import ca.nrc.cadc.ac.GroupURI;
 import ca.nrc.cadc.beacon.FileSizeRepresentation;
 import ca.nrc.cadc.date.DateUtil;
 import ca.nrc.cadc.vos.VOSURI;
@@ -91,8 +92,8 @@ public abstract class StorageItem
     private final String name;
     private final long sizeInBytes;
     private final Date lastModified;
-    private final URI[] writeGroupURIs;
-    private final URI[] readGroupURIs;
+    private final GroupURI[] writeGroupURIs;
+    private final GroupURI[] readGroupURIs;
     private final String owner;
     private final boolean readableFlag;
 
@@ -107,7 +108,7 @@ public abstract class StorageItem
 
 
     StorageItem(VOSURI uri, long sizeInBytes, Date lastModified, boolean publicFlag, boolean lockedFlag,
-                URI[] writeGroupURIs, URI[] readGroupURIs, final String owner, boolean readableFlag,
+                GroupURI[] writeGroupURIs, GroupURI[] readGroupURIs, final String owner, boolean readableFlag,
                 boolean writableFlag, String targetURL)
     {
         this.uri = uri;
@@ -218,13 +219,13 @@ public abstract class StorageItem
         }
     }
 
-    private String getURINames(final URI[] uris)
+    private String getURINames(final GroupURI[] uris)
     {
         final StringBuilder uriNames = new StringBuilder();
 
-        for (final URI uri : uris)
+        for (final GroupURI uri : uris)
         {
-            uriNames.append(uri.getFragment()).append(" ");
+            uriNames.append(uri.getName()).append(" ");
         }
 
         return uriNames.toString().trim();


### PR DESCRIPTION
…names are displayed correctly to UI.  Change of using # to ? for group URIs led to 'null' being displayed for read and write group names in the storage ui. GroupURI class handles both characters.