### PR TITLE
CADC-1290: remove sort & reverse collection statements

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -21,7 +21,7 @@ def git_url = 'https://github.com/opencadc/cadc-vosui.git'
 
 sourceCompatibility = '1.8'
 group = 'org.opencadc'
-version = '1.2.4'
+version = '1.2.5'
 
 dependencies {
     implementation 'org.freemarker:freemarker:[2.3.31,2.4.0)'

--- a/src/main/java/ca/nrc/cadc/beacon/web/config/VOSpaceServiceConfigMgr.java
+++ b/src/main/java/ca/nrc/cadc/beacon/web/config/VOSpaceServiceConfigMgr.java
@@ -166,7 +166,10 @@ public class VOSpaceServiceConfigMgr {
     }
 
     public List<String> getServiceList() {
-        return this.serviceList;
+        final List<String> listToSort = new ArrayList<>(this.serviceList);
+        Collections.sort(listToSort);
+        Collections.reverse(listToSort);
+        return listToSort;
     }
 
 }

--- a/src/main/java/ca/nrc/cadc/beacon/web/config/VOSpaceServiceConfigMgr.java
+++ b/src/main/java/ca/nrc/cadc/beacon/web/config/VOSpaceServiceConfigMgr.java
@@ -119,7 +119,7 @@ public class VOSpaceServiceConfigMgr {
         this.serviceList = Arrays.asList(appConfig.lookupAll(VOSPACE_SERVICE_NAME_KEY));
 
         for (String storageServiceName: this.serviceList) {
-            log.debug("adding vospace service to map: " + VOSPACE_SERVICE_NAME_KEY + ": " + serviceList.toString());
+            log.debug("adding vospace service to map: " + VOSPACE_SERVICE_NAME_KEY + ": " + storageServiceName);
 
             String vospaceResourceIDStr = appConfig.lookup(KEY_BASE + storageServiceName + SERVICE_RESOURCEID_KEY);
             URI vospaceResourceID;
@@ -142,9 +142,9 @@ public class VOSpaceServiceConfigMgr {
                 vospaceResourceID, nodeResourceID);
 
             String userHomeDir = KEY_BASE + storageServiceName + USER_HOME_KEY;
-            log.debug("user home directory: " + userHomeDir);
             String userHomeValue = appConfig.lookup(userHomeDir);
             if (StringUtil.hasLength(userHomeDir)) {
+                log.debug("user home directory: " + userHomeDir + ": " + userHomeValue);
                 newConfig.homeDir = userHomeValue;
             }
 
@@ -169,6 +169,7 @@ public class VOSpaceServiceConfigMgr {
         final List<String> listToSort = new ArrayList<>(this.serviceList);
         Collections.sort(listToSort);
         Collections.reverse(listToSort);
+        log.debug("sorted service list: " + listToSort.toString());
         return listToSort;
     }
 

--- a/src/main/java/ca/nrc/cadc/beacon/web/config/VOSpaceServiceConfigMgr.java
+++ b/src/main/java/ca/nrc/cadc/beacon/web/config/VOSpaceServiceConfigMgr.java
@@ -166,8 +166,6 @@ public class VOSpaceServiceConfigMgr {
     }
 
     public List<String> getServiceList() {
-        Collections.sort(this.serviceList);
-        Collections.reverse(this.serviceList);
         return this.serviceList;
     }
 


### PR DESCRIPTION
possible fix for config issues in User Storage. Statements don't do anything useful, might be harmful if run concurrently.