### PR TITLE
CADC-10478: enable multi-select on data table

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -21,7 +21,7 @@ def git_url = 'https://github.com/opencadc/cadc-vosui.git'
 
 sourceCompatibility = '1.8'
 group = 'org.opencadc'
-version = '1.2.5'
+version = '1.2.6'
 
 dependencies {
     implementation 'org.freemarker:freemarker:[2.3.31,2.4.0)'

--- a/src/main/resources/META-INF/resources/js/filemanager.js
+++ b/src/main/resources/META-INF/resources/js/filemanager.js
@@ -120,8 +120,13 @@ function fileManager(
   })
 
   var selectInput = {
-    style: 'os',
-    selector: 'td:first-child.select-checkbox'
+    // CADC-10478: had been 'os' prior, 'multi' allows rows
+    // to function same as Advanced Search - click selects,
+    // without clearing previous selections. 'multi+shift'
+    // allows shift+click and command+click options to still
+    // function.
+    style: 'multi+shift',
+    selector: 'td:first-child.select-checkbox',
   }
 
   var $fileInfo = $('#fileInfo')
@@ -3515,4 +3520,5 @@ function fileManager(
   $(window).load(function() {
     setDimensions()
   })
+
 }


### PR DESCRIPTION
Found reference here:
https://datatables.net/reference/option/select.style

Allows for clicks to accumulate selects, plus the shift+click & ctrl+click behaviour is retained. 