### PR TITLE
CADC-10477: add timeout to package generation prompt, make sure no request for arc nodes

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -21,7 +21,7 @@ def git_url = 'https://github.com/opencadc/cadc-vosui.git'
 
 sourceCompatibility = '1.8'
 group = 'org.opencadc'
-version = '1.2.8'
+version = '1.2.9'
 
 dependencies {
     implementation 'org.freemarker:freemarker:[2.3.31,2.4.0)'

--- a/src/main/resources/META-INF/resources/js/filemanager.js
+++ b/src/main/resources/META-INF/resources/js/filemanager.js
@@ -2530,60 +2530,66 @@ function fileManager(
     var $thisLink = $(this)
 
     if ($thisLink.attr('class') === 'download-zip-file') {
-      var postData = {}
-      postData.responseformat = 'application/zip'
-      var targetList = new Array();
 
-      $.each(
-        $dt
-          .rows({
-            selected: true
-          })
-          .data(),
-        function (key, itemData) {
-          targetList.push(itemData[10])
-        }
-      )
+      // CADC-10355: zip download only available for vault.
+      // if the element is disabled, do not attempt to post request.
+      if ($thisLink.attr('disabled') !== 'disabled') {
+        var postData = {}
+        postData.responseformat = 'application/zip'
+        var targetList = new Array();
 
-      postData.targets = targetList
-
-      $.ajax({
-        method: 'POST',
-        url:
-          contextPath +
-          vospaceServicePath +
-          config.options.packageConnector,
-        data: JSON.stringify(postData),
-        contentType: 'application/json',
-        success: function( data, textStatus, jqXHR) {
-          var infoMsg = data.msg;
-
-          var $anchor = $('<a/>')
-            .attr('href',  data.endpoint)
-            .attr('display', 'none')
-
-          // Append to the document body temporarily
-          // so package url can be clicked and the package
-          // file download handled by the browser
-          $('#main_section').append($anchor)
-          // Must trigger the native click event manually - jquery
-          // blocks this for links.
-          $anchor.get(0).click()
-          $anchor.remove()
-
-          $.prompt(lg.package_generate)
-
-        },
-        error: function(jqXHR, textStatus, errorThrown) {
-          var errMsg = ''
-
-          switch (jqXHR.status) {
-            default:
-              errMsg = getErrorMsg(jqXHR, errorThrown)
+        $.each(
+          $dt
+            .rows({
+              selected: true
+            })
+            .data(),
+          function (key, itemData) {
+            targetList.push(itemData[10])
           }
-          $.prompt(errMsg)
-        }
-      })
+        )
+
+        postData.targets = targetList
+
+        $.ajax({
+          method: 'POST',
+          url:
+            contextPath +
+            vospaceServicePath +
+            config.options.packageConnector,
+          data: JSON.stringify(postData),
+          contentType: 'application/json',
+          success: function (data, textStatus, jqXHR) {
+            var infoMsg = data.msg;
+
+            var $anchor = $('<a/>')
+              .attr('href', data.endpoint)
+              .attr('display', 'none')
+
+            // Append to the document body temporarily
+            // so package url can be clicked and the package
+            // file download handled by the browser
+            $('#main_section').append($anchor)
+            // Must trigger the native click event manually - jquery
+            // blocks this for links.
+            $anchor.get(0).click()
+            $anchor.remove()
+
+            // timeout is in ms
+            $.prompt(lg.package_generate, {'timeout': 3500 })
+
+          },
+          error: function (jqXHR, textStatus, errorThrown) {
+            var errMsg = ''
+
+            switch (jqXHR.status) {
+              default:
+                errMsg = getErrorMsg(jqXHR, errorThrown)
+            }
+            $.prompt(errMsg)
+          }
+        })
+      }
 
     } else {
       var downloadMethod = config.download.methods[$thisLink.attr('class')]


### PR DESCRIPTION
- 'if' added to make sure zip element is NOT disabled before submitting package request
- add timeout to prompt shown on package generation (listening to browser window for download too problematic, this is the best solution to having the prompt go away on its own.)